### PR TITLE
Allow multi-language support for SpeechToText

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
@@ -50,7 +50,7 @@ public class RNSpeechToTextModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void changeModel(String model){
-        // For a list of models visit
+        // For the list of models, see:
         // https://console.bluemix.net/docs/services/speech-to-text/input.html#models
 
         this.model = model;

--- a/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
@@ -49,16 +49,11 @@ public class RNSpeechToTextModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setModel(String model){
+    public void changeModel(String model){
         // For a list of models visit
         // https://console.bluemix.net/docs/services/speech-to-text/input.html#models
 
         this.model = model;
-    }
-
-    @ReactMethod
-    public String getModel(){
-        return this.model;
     }
 
     @ReactMethod

--- a/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSpeechToTextModule.java
@@ -29,6 +29,7 @@ public class RNSpeechToTextModule extends ReactContextBaseJavaModule {
     private SpeechToText service = new SpeechToText();
     private MicrophoneInputStream capture;
     private Callback errorCallback;
+    private String model = "en-US_BroadbandModel";
 
     public RNSpeechToTextModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -45,6 +46,19 @@ public class RNSpeechToTextModule extends ReactContextBaseJavaModule {
     public void initialize(String username, String password) {
         service.setUsernameAndPassword(username, password);
         service.setEndPoint("https://stream.watsonplatform.net/speech-to-text/api");
+    }
+
+    @ReactMethod
+    public void setModel(String model){
+        // For a list of models visit
+        // https://console.bluemix.net/docs/services/speech-to-text/input.html#models
+
+        this.model = model;
+    }
+
+    @ReactMethod
+    public String getModel(){
+        return this.model;
     }
 
     @ReactMethod
@@ -73,7 +87,7 @@ public class RNSpeechToTextModule extends ReactContextBaseJavaModule {
     private RecognizeOptions getRecognizeOptions() {
         return new RecognizeOptions.Builder()
                 .contentType(ContentType.OPUS.toString())
-                .model("en-US_BroadbandModel")
+                .model(model)
                 .interimResults(true)
                 .inactivityTimeout(2000)
                 .build();

--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ module.exports = {
         },
 
         changeModel(model){
+            // For the list of models, see:
+            // https://console.bluemix.net/docs/services/speech-to-text/input.html#models
             RNSpeechToText.changeModel(model)
         },
 

--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ module.exports = {
             RNSpeechToText.startStreaming( callback )
         },
 
+        changeModel(model){
+            RNSpeechToText.changeModel(model)
+        },
+
         stopStreaming()
         {
             this.subscription.remove()

--- a/ios/RNWatson.swift
+++ b/ios/RNWatson.swift
@@ -109,6 +109,8 @@ class RNSpeechToText: RCTEventEmitter {
   }
 
   @objc func changeModel(_ modelName: String) -> Void {
+    // For the list of models, see:
+    // https://console.bluemix.net/docs/services/speech-to-text/input.html#models
     speechToText?.getModels(success: {(models: [Model]) -> Void in
       for model in models {
         if model.name == modelName {

--- a/ios/RNWatson.swift
+++ b/ios/RNWatson.swift
@@ -108,7 +108,7 @@ class RNSpeechToText: RCTEventEmitter {
     }
   }
 
-  @objc func setModel(_ modelName: String) -> Void {
+  @objc func changeModel(_ modelName: String) -> Void {
     speechToText?.getModels(success: {(models: [Model]) -> Void in
       for model in models {
         if model.name == modelName {

--- a/ios/RNWatson.swift
+++ b/ios/RNWatson.swift
@@ -79,6 +79,7 @@ class RNSpeechToText: RCTEventEmitter {
   var audioPlayer = AVAudioPlayer()
   var callback: RCTResponseSenderBlock?
   var hasListeners = false
+  var model: String?
   
   static let sharedInstance = RNSpeechToText()
   
@@ -99,12 +100,23 @@ class RNSpeechToText: RCTEventEmitter {
     
     let failure = { (error: Error) in errorCallback([error]) }
     
-    speechToText?.recognizeMicrophone(settings: settings, failure: failure) { results in
+    speechToText?.recognizeMicrophone(settings: settings, model: self.model, failure: failure) { results in
       if(self.hasListeners)
       {
         self.sendEvent(withName: "StreamingText", body: results.bestTranscript)
       }
     }
+  }
+
+  @objc func setModel(_ modelName: String) -> Void {
+    speechToText?.getModels(success: {(models: [Model]) -> Void in
+      for model in models {
+        if model.name == modelName {
+          self.model = model.name
+          break
+        }
+      }
+    })
   }
   
   @objc func stopStreaming() {


### PR DESCRIPTION
The changes in this PR allow the developer to change the model of IBM Watson's SpeechToText module, allowing it to understand languages other than the default, English.

These changes are made from the Native side of both iOS (Swift) and Android (Java) to allow both platforms to have multi-language speech recognition.

I was learning Swift as I was writing this PR, so please if you see any errors, let me know! Thanks

To change the model, just call `changeModel` function like so: `SpeechToText.changeModel('es-ES_BroadbandModel')`, where 'es-ES_BroadbandModel' is the desired model for the language you wish to recognize, which is Spanish in this case.

To see supported languages, see https://console.bluemix.net/docs/services/speech-to-text/input.html#models